### PR TITLE
Add delete API test with Vitest script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "build": "vite build",
         "preview": "vite preview",
         "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-        "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+        "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+        "test": "vitest run"
     },
     "devDependencies": {
         "@skeletonlabs/skeleton": "^2.7.1",
@@ -32,6 +33,7 @@
         "dotenv": "^16.3.1",
         "jspdf": "^2.5.1",
         "postgres": "^3.3.5",
-        "sk-form-data": "^1.0.1"
+        "sk-form-data": "^1.0.1",
+        "vitest": "^1.5.0"
     }
 }

--- a/src/lib/services/dataService.test.ts
+++ b/src/lib/services/dataService.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DataService } from './dataService';
+
+describe('DataService.deleteRecord', () => {
+    it('calls fetch with the correct URL and method', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: vi.fn() });
+        const originalFetch = global.fetch;
+        // @ts-ignore
+        global.fetch = mockFetch;
+
+        await DataService.deleteRecord(123);
+
+        expect(mockFetch).toHaveBeenCalledWith('/api/deleteRowId/123', {
+            method: 'DELETE'
+        });
+
+        // restore original fetch
+        global.fetch = originalFetch;
+    });
+});
+


### PR DESCRIPTION
## Summary
- add `vitest run` test script and declare Vitest dev dependency
- create `dataService.deleteRecord` test verifying fetch call

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894eec2dee48330a625f1d262467bef